### PR TITLE
chore: 散在する定数を lib/constants.ts と lib/sample-data.ts に集約

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { StatsRow } from "@/components/StatsRow"
 import { computeDiff } from "@/lib/diff-engine"
 import { useUndoStack } from "@/hooks/useUndoStack"
 import { MAX_TEXT_LENGTH } from "@/lib/constants"
+import { SAMPLE_A, SAMPLE_B } from "@/lib/sample-data"
 import type {
   WordMode,
   Theme,
@@ -18,29 +19,6 @@ import type {
   IgnoreOptions,
   ColorMode,
 } from "@/lib/types"
-
-const SAMPLE_A = `探偵の田中は、深夜12時に依頼人から電話を受けた。
-「ダイヤモンドが消えた」と声は震えていた。
-現場はNewYorkの高級ホテル、MacDonald Suiteの305号室。
-The suspect left no fingerprints at the scene.
-部屋には不審な足跡と、半分飲まれたワインが残されていた。
-金庫は無傷のまま、窓だけが開け放たれていた。
-The quick brown fox jumps over the lazy dog.
-田中は静かにメモを取りながら、容疑者を絞り込んでいった。
-容疑者リスト: 3名
-この行はオリジナルにのみ存在する。`
-
-const SAMPLE_B = `探偵の鈴木は、深夜12時に依頼人から電話を受けた。
-「エメラルドが消えた」と声は震えていた。
-現場はNewJerseyの高級ホテル、MacArthur Suiteの305号室。
-The Suspect left no Fingerprints at the scene.
-部屋には不審な足跡と、半分飲まれたワインが残されていた。
-  金庫は無傷のまま、窓だけが開け放たれていた。
-The quick brown cat jumps over the lazy　dog.
-鈴木は静かにメモを取りながら、容疑者 を絞り込んでいった。
-
-容疑者リスト： 5名
-この行は改訂版にのみ存在する。`
 
 export default function Home() {
   const [textA, setTextA] = useState(SAMPLE_A)

--- a/components/OptionsBar.tsx
+++ b/components/OptionsBar.tsx
@@ -3,12 +3,12 @@
 import { CircleHelp } from "lucide-react"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import type { WordMode, Theme, DiffDisplayMode, IgnoreOptions } from "@/lib/types"
-
-interface SegmentOption<T extends string> {
-  value: T
-  label: string
-  tooltip?: string
-}
+import {
+  WORD_MODE_OPTIONS,
+  THEME_OPTIONS,
+  DIFF_DISPLAY_MODE_OPTIONS,
+  type SegmentOption,
+} from "@/lib/constants"
 
 function SegmentedControl<T extends string>({
   options,
@@ -72,38 +72,26 @@ export function OptionsBar({
   onDisplayModeChange,
   onIgnoreOptionsChange,
 }: OptionsBarProps) {
-  const wordModeOptions: SegmentOption<WordMode>[] = [
-    { value: "word", label: "単語" },
-    { value: "char", label: "1文字" },
-  ]
-
-  const themeOptions: SegmentOption<Theme>[] = [
-    { value: "color1", label: "青" },
-    { value: "color2", label: "緑" },
-    { value: "mono", label: "モノ" },
-  ]
-
-  const displayOptions: SegmentOption<DiffDisplayMode>[] = [
-    { value: "all", label: "全体" },
-    { value: "diff-only", label: "差分のみ" },
-  ]
-
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
       <div className="flex items-center gap-1.5">
         <span className="text-xs text-muted-foreground">比較</span>
-        <SegmentedControl options={wordModeOptions} value={wordMode} onChange={onWordModeChange} />
+        <SegmentedControl
+          options={WORD_MODE_OPTIONS}
+          value={wordMode}
+          onChange={onWordModeChange}
+        />
       </div>
 
       <div className="flex items-center gap-1.5">
         <span className="text-xs text-muted-foreground">配色</span>
-        <SegmentedControl options={themeOptions} value={theme} onChange={onThemeChange} />
+        <SegmentedControl options={THEME_OPTIONS} value={theme} onChange={onThemeChange} />
       </div>
 
       <div className="flex items-center gap-1.5">
         <span className="text-xs text-muted-foreground">表示</span>
         <SegmentedControl
-          options={displayOptions}
+          options={DIFF_DISPLAY_MODE_OPTIONS}
           value={displayMode}
           onChange={onDisplayModeChange}
         />

--- a/hooks/useUndoStack.ts
+++ b/hooks/useUndoStack.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react"
 import type { DiffResult } from "@/lib/types"
+import { UNDO_MAX_DEPTH } from "@/lib/constants"
 
 export interface UndoState {
   textA: string
@@ -10,13 +11,11 @@ export interface UndoState {
   resultVersion: number
 }
 
-const MAX_DEPTH = 10
-
 export function useUndoStack() {
   const [stack, setStack] = useState<UndoState[]>([])
 
   const push = useCallback((state: UndoState) => {
-    setStack((prev) => [...prev, state].slice(-MAX_DEPTH))
+    setStack((prev) => [...prev, state].slice(-UNDO_MAX_DEPTH))
   }, [])
 
   const pop = useCallback((): UndoState | null => {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,27 @@
+import type { WordMode, Theme, DiffDisplayMode } from "@/lib/types"
+
 export const MAX_TEXT_LENGTH = 200_000
+
+export const UNDO_MAX_DEPTH = 10
+
+export interface SegmentOption<T extends string> {
+  value: T
+  label: string
+  tooltip?: string
+}
+
+export const WORD_MODE_OPTIONS: SegmentOption<WordMode>[] = [
+  { value: "word", label: "単語" },
+  { value: "char", label: "1文字" },
+]
+
+export const THEME_OPTIONS: SegmentOption<Theme>[] = [
+  { value: "color1", label: "青" },
+  { value: "color2", label: "緑" },
+  { value: "mono", label: "モノ" },
+]
+
+export const DIFF_DISPLAY_MODE_OPTIONS: SegmentOption<DiffDisplayMode>[] = [
+  { value: "all", label: "全体" },
+  { value: "diff-only", label: "差分のみ" },
+]

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -1,0 +1,22 @@
+export const SAMPLE_A = `探偵の田中は、深夜12時に依頼人から電話を受けた。
+「ダイヤモンドが消えた」と声は震えていた。
+現場はNewYorkの高級ホテル、MacDonald Suiteの305号室。
+The suspect left no fingerprints at the scene.
+部屋には不審な足跡と、半分飲まれたワインが残されていた。
+金庫は無傷のまま、窓だけが開け放たれていた。
+The quick brown fox jumps over the lazy dog.
+田中は静かにメモを取りながら、容疑者を絞り込んでいった。
+容疑者リスト: 3名
+この行はオリジナルにのみ存在する。`
+
+export const SAMPLE_B = `探偵の鈴木は、深夜12時に依頼人から電話を受けた。
+「エメラルドが消えた」と声は震えていた。
+現場はNewJerseyの高級ホテル、MacArthur Suiteの305号室。
+The Suspect left no Fingerprints at the scene.
+部屋には不審な足跡と、半分飲まれたワインが残されていた。
+  金庫は無傷のまま、窓だけが開け放たれていた。
+The quick brown cat jumps over the lazy　dog.
+鈴木は静かにメモを取りながら、容疑者 を絞り込んでいった。
+
+容疑者リスト： 5名
+この行は改訂版にのみ存在する。`


### PR DESCRIPTION
# 概要

各コンポーネントに散在していた定数・サンプルデータを専用ファイルに集約し、保守性を向上させる。

## 関連Issue

なし

## 変更内容

- `lib/constants.ts` に `UNDO_MAX_DEPTH`、`WORD_MODE_OPTIONS`、`THEME_OPTIONS`、`DIFF_DISPLAY_MODE_OPTIONS` を追加
- `lib/sample-data.ts` を新規作成し `SAMPLE_A` / `SAMPLE_B` を移動
- `hooks/useUndoStack.ts` のローカル `MAX_DEPTH` を `UNDO_MAX_DEPTH` の import に置換
- `components/OptionsBar.tsx` のハードコードされたオプション配列を constants から import に変更
- `app/page.tsx` のサンプルデータを `lib/sample-data.ts` から import に変更

## 補足

- 動作に変更はなく、定数の配置場所の整理のみ
- `SegmentOption` インターフェースも `lib/constants.ts` に移動し export