### PR TITLE
feat: diff表示セクションにErrorBoundaryを追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { InputPanel } from "@/components/InputPanel"
 import { OptionsBar } from "@/components/OptionsBar"
 import { DiffViewer } from "@/components/DiffViewer"
 import { StatsRow } from "@/components/StatsRow"
+import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { useTextInput } from "@/hooks/useTextInput"
 import { useDiffCompare } from "@/hooks/useDiffCompare"
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts"
@@ -110,13 +111,13 @@ export default function Home() {
           />
 
           {result && (
-            <>
+            <ErrorBoundary>
               <DiffViewer key={resultVersion} result={result} displayMode={displayMode} />
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <StatsRow label="テキスト A" stats={result.statsA} />
                 <StatsRow label="テキスト B" stats={result.statsB} />
               </div>
-            </>
+            </ErrorBoundary>
           )}
         </div>
       </div>

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Component } from "react"
+import type { ErrorInfo, ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-6 text-center">
+          <p className="text-sm font-medium text-destructive">表示中にエラーが発生しました</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            onClick={() => this.setState({ hasError: false })}
+          >
+            再試行
+          </Button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}


### PR DESCRIPTION
# 概要

diff 表示セクションで予期しないレンダリングエラーが発生した場合に、アプリ全体がクラッシュするのを防ぐため ErrorBoundary を追加。

## 関連Issue

なし

## 変更内容

- `components/ErrorBoundary.tsx` を新規作成（React class component）
  - `getDerivedStateFromError` / `componentDidCatch` でエラーをキャッチ
  - フォールバック UI（エラーメッセージ + 再試行ボタン）を表示
- `app/page.tsx` の diff 表示セクション（`DiffViewer` + `StatsRow`）を `<ErrorBoundary>` でラップ

## 補足

- React の仕様上、Error Boundary は class component で実装する必要がある
- 再試行ボタンで `hasError` をリセットし、子コンポーネントの再描画を試みる