### PR TITLE
feat: InputPanelにファイルドラッグ&ドロップとファイル選択を追加

### DIFF
--- a/components/InputPanel.tsx
+++ b/components/InputPanel.tsx
@@ -8,7 +8,15 @@ import { ArrowLeftRight, Upload, X } from "lucide-react"
 import { MAX_TEXT_LENGTH } from "@/lib/constants"
 
 const ACCEPTED_EXTENSIONS = [".txt", ".md", ".csv", ".json", ".xml", ".html"]
-const ACCEPTED_MIME_TYPES = "text/plain,text/markdown,text/csv,application/json,text/xml,text/html"
+const ACCEPTED_MIME_TYPES = [
+  ...ACCEPTED_EXTENSIONS,
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+  "text/xml",
+  "text/html",
+].join(",")
 
 function readFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
# 概要

InputPanelの各テキストエリアにファイルドラッグ&ドロップおよびファイル選択ボタンを追加し、テキストファイルから直接内容を読み込めるようにした。

## 関連Issue

なし

## 変更内容

- テキスト A / B 各エリアに `onDragEnter` / `onDragOver` / `onDragLeave` / `onDrop` ハンドラを追加
- ドラッグ中の視覚フィードバック（`ring-2 ring-primary` + 背景色変更）
- `dragCounter` ref で子要素出入りによる `dragLeave` 誤発火を防止
- `FileReader.readAsText(file, "UTF-8")` でファイル内容を読み込み
- 対応拡張子: `.txt`, `.md`, `.csv`, `.json`, `.xml`, `.html`
- 非対応ファイル形式のエラーメッセージ表示
- 複数ファイルドロップ時は最初の1ファイルのみ読み込み
- モバイル向けにUploadアイコンボタン + 隠し `<input type="file">` を追加
- プレースホルダーを「ファイルをドロップ...」に更新

## 補足

- 200,000文字制限は既存の `overLimit` バリデーションがそのまま機能するため追加対応不要
- ESLint `react-hooks/refs` ルールに対応するため、ハンドラファクトリパターンではなく個別ハンドラで実装