### PR TITLE
feat: OptionsBar と差分ナビゲーションを sticky 固定表示化

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import { Moon, Sun } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { InputPanel } from "@/components/InputPanel"
@@ -42,16 +42,19 @@ export default function Home() {
     isComparing,
     handleCompare,
     optionsChanged,
+    lastComparedOptions,
+    setLastComparedOptions,
   } = useDiffCompare(textA, textB, wordMode, ignoreOptions)
 
-  const diffSnapshot = { result, resultVersion }
+  const diffSnapshot = { result, resultVersion, lastComparedOptions }
 
   const handleUndo = useCallback(() => {
     const state = restoreFromUndo()
     if (!state) return
     setResult(state.result)
     setResultVersion(state.resultVersion)
-  }, [restoreFromUndo, setResult, setResultVersion])
+    setLastComparedOptions(state.lastComparedOptions)
+  }, [restoreFromUndo, setResult, setResultVersion, setLastComparedOptions])
 
   useKeyboardShortcuts({
     onCompare: handleCompare,
@@ -66,6 +69,18 @@ export default function Home() {
   const handleThemeChange = useCallback((t: Theme) => {
     setTheme(t)
     document.documentElement.setAttribute("data-theme", t)
+  }, [])
+
+  // OptionsBar ラッパーの高さを計測し CSS 変数に反映
+  const optionsBarRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = optionsBarRef.current
+    if (!el) return
+    const observer = new ResizeObserver(() => {
+      document.documentElement.style.setProperty("--sticky-bar-height", `${el.offsetHeight}px`)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
   }, [])
 
   return (
@@ -103,7 +118,10 @@ export default function Home() {
             }}
           />
 
-          <div className="sticky top-0 z-10 flex flex-wrap items-center gap-x-4 gap-y-2 bg-background pt-2 pb-2">
+          <div
+            ref={optionsBarRef}
+            className="sticky top-0 z-10 flex flex-wrap items-center gap-x-4 gap-y-2 bg-background pt-2 pb-2"
+          >
             <OptionsBar
               wordMode={wordMode}
               theme={theme}

--- a/components/DiffViewer.tsx
+++ b/components/DiffViewer.tsx
@@ -91,7 +91,10 @@ export function DiffViewer({ result, displayMode }: DiffViewerProps) {
 
   return (
     <div className="space-y-2">
-      <div className="sticky top-10 z-5 flex items-center gap-1.5 bg-background py-1 text-xs text-muted-foreground">
+      <div
+        className="sticky z-5 flex items-center gap-1.5 bg-background py-1 text-xs text-muted-foreground"
+        style={{ top: "var(--sticky-bar-height, 2.5rem)" }}
+      >
         <span className="tabular-nums" aria-live="polite" aria-atomic="true">
           {currentChangeIdx >= 0 ? currentChangeIdx + 1 : "-"} / {changeIndices.length} 件
         </span>

--- a/hooks/useDiffCompare.ts
+++ b/hooks/useDiffCompare.ts
@@ -65,5 +65,7 @@ export function useDiffCompare(
     canCompare,
     handleCompare,
     optionsChanged,
+    lastComparedOptions,
+    setLastComparedOptions,
   }
 }

--- a/hooks/useTextInput.ts
+++ b/hooks/useTextInput.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from "react"
 import { useUndoStack, type UndoState } from "@/hooks/useUndoStack"
-import type { DiffResult } from "@/lib/types"
+import type { DiffResult, WordMode, IgnoreOptions } from "@/lib/types"
 
 const SAMPLE_A = `探偵の田中は、深夜12時に依頼人から電話を受けた。
 「ダイヤモンドが消えた」と声は震えていた。
@@ -30,6 +30,7 @@ The quick brown cat jumps over the lazy　dog.
 interface DiffSnapshot {
   result: DiffResult | null
   resultVersion: number
+  lastComparedOptions: { wordMode: WordMode; ignoreOptions: IgnoreOptions } | null
 }
 
 export function useTextInput() {

--- a/hooks/useUndoStack.ts
+++ b/hooks/useUndoStack.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
-import type { DiffResult } from "@/lib/types"
+import type { DiffResult, WordMode, IgnoreOptions } from "@/lib/types"
 import { UNDO_MAX_DEPTH } from "@/lib/constants"
 
 export interface UndoState {
@@ -9,6 +9,7 @@ export interface UndoState {
   textB: string
   result: DiffResult | null
   resultVersion: number
+  lastComparedOptions: { wordMode: WordMode; ignoreOptions: IgnoreOptions } | null
 }
 
 export function useUndoStack() {


### PR DESCRIPTION
# 概要

スクロール時に OptionsBar と差分ナビゲーション（前/次の変更箇所）を画面上部に固定表示するようにした。
また、比較結果の表示中にオプション（比較モード・空白無視）を変更した場合、
⌘+Enter で再比較できる旨のヒントを OptionsBar 横にインライン表示する機能を追加した。

## 関連Issue

なし

## 変更内容

- `app/page.tsx`: OptionsBar を `sticky top-0` のラッパーで固定表示化。再比較ヒントをインライン表示
- `components/DiffViewer.tsx`: 前/次ナビゲーションバーに `sticky top-10` を追加し OptionsBar 下に固定
- `hooks/useDiffCompare.ts`: 比較時のオプション（wordMode, ignoreOptions）を記録し `optionsChanged` を返却

## 補足

- DiffViewer のナビバーの `top-10`（40px）は OptionsBar の高さに基づく固定値。モバイルで OptionsBar が折り返した場合に若干ずれる可能性あり
- InputPanel の比較・クリアボタンの位置は変更なし