### PR TITLE
feat: クリアボタンにキーボードショートカット (Cmd/Ctrl+Shift+X) を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,6 +66,7 @@ export default function Home() {
   }, [restoreFromUndo, setResult, setResultVersion, setLastComparedOptions])
 
   const handleClear = () => {
+    if (textA.length === 0 && textB.length === 0) return
     handleClearAll(diffSnapshot)
     setResult(null)
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,9 +65,15 @@ export default function Home() {
     setLastComparedOptions(state.lastComparedOptions)
   }, [restoreFromUndo, setResult, setResultVersion, setLastComparedOptions])
 
+  const handleClear = () => {
+    handleClearAll(diffSnapshot)
+    setResult(null)
+  }
+
   useKeyboardShortcuts({
     onCompare: handleCompare,
     onUndo: handleUndo,
+    onClear: handleClear,
   })
 
   /** Tailwind CSS のダークモードクラスを document に切り替える */
@@ -123,10 +129,7 @@ export default function Home() {
             onSwap={() => handleSwap(diffSnapshot)}
             isComparing={isComparing}
             onCompare={handleCompare}
-            onClear={() => {
-              handleClearAll(diffSnapshot)
-              setResult(null)
-            }}
+            onClear={handleClear}
           />
 
           <div

--- a/components/InputPanel.tsx
+++ b/components/InputPanel.tsx
@@ -309,14 +309,21 @@ export function InputPanel({
             <kbd className="font-mono text-[10px]">⌘+Enter</kbd>
           </TooltipContent>
         </Tooltip>
-        <Button
-          variant="ghost"
-          onClick={onClear}
-          disabled={textA.length === 0 && textB.length === 0}
-          className="text-muted-foreground"
-        >
-          クリア
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              onClick={onClear}
+              disabled={textA.length === 0 && textB.length === 0}
+              className="text-muted-foreground"
+            >
+              クリア
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <kbd className="font-mono text-[10px]">⌘+Shift+X</kbd>
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 /**
  * グローバルキーボードショートカットを登録するフック。
- * Cmd/Ctrl+Enter で比較実行、Cmd/Ctrl+Z で Undo を発火する。
+ * Cmd/Ctrl+Enter で比較実行、Cmd/Ctrl+Z で Undo、Cmd/Ctrl+Shift+X でクリアを発火する。
  */
 
 "use client"
@@ -10,17 +10,20 @@ import { useRef, useEffect } from "react"
 interface KeyboardShortcutHandlers {
   onCompare: () => void
   onUndo: () => void
+  onClear: () => void
 }
 
-export function useKeyboardShortcuts({ onCompare, onUndo }: KeyboardShortcutHandlers) {
+export function useKeyboardShortcuts({ onCompare, onUndo, onClear }: KeyboardShortcutHandlers) {
   // ref でコールバックを保持し、useEffect の依存配列を空にして
   // リスナーの再登録を防ぐ
   const compareRef = useRef(onCompare)
   const undoRef = useRef(onUndo)
+  const clearRef = useRef(onClear)
 
   useEffect(() => {
     compareRef.current = onCompare
     undoRef.current = onUndo
+    clearRef.current = onClear
   })
 
   useEffect(() => {
@@ -35,6 +38,10 @@ export function useKeyboardShortcuts({ onCompare, onUndo }: KeyboardShortcutHand
         if (tag === "TEXTAREA" || tag === "INPUT") return
         e.preventDefault()
         undoRef.current()
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.code === "KeyX") {
+        e.preventDefault()
+        clearRef.current()
       }
     }
     window.addEventListener("keydown", handleKeyDown)


### PR DESCRIPTION
# 概要

クリア操作をキーボードショートカット (Cmd/Ctrl+Shift+X) で実行できるようにする。
クリアボタンにショートカットキーのツールチップも追加。

## 関連Issue

closes #28

## 変更内容

- `useKeyboardShortcuts` フックに `onClear` コールバックと Cmd/Ctrl+Shift+X ハンドラを追加
- `page.tsx` の `handleClear` を関数として抽出し、ショートカットと InputPanel で共有
- クリアボタンに Tooltip (`⌘+Shift+X`) を追加

## 補足

- キー判定には `e.code === "KeyX"` を使用（`e.key` は修飾キーの組み合わせでブラウザ差異があるため）
- textarea にフォーカス中でもショートカットが動作する（クリアはアプリ操作のため）