### PR TITLE
feat: トップへ戻るボタンを画面右下に設置 (#29)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { OptionsBar } from "@/components/OptionsBar"
 import { DiffViewer } from "@/components/DiffViewer"
 import { StatsRow } from "@/components/StatsRow"
 import { ErrorBoundary } from "@/components/ErrorBoundary"
+import { ScrollToTopButton } from "@/components/ScrollToTopButton"
 import { useTextInput } from "@/hooks/useTextInput"
 import { useDiffCompare } from "@/hooks/useDiffCompare"
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts"
@@ -168,6 +169,8 @@ export default function Home() {
           )}
         </div>
       </div>
+
+      <ScrollToTopButton />
     </div>
   )
 }

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { ArrowUp } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
+
+const SCROLL_THRESHOLD = 300
+
+export function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false)
+  const visibleRef = useRef(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      const shouldShow = window.scrollY > SCROLL_THRESHOLD
+      if (shouldShow !== visibleRef.current) {
+        visibleRef.current = shouldShow
+        setVisible(shouldShow)
+      }
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
+
+  const scrollToTop = () => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" })
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className={`fixed bottom-4 right-4 z-20 shadow-md transition-all duration-200 ${
+            visible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0"
+          }`}
+          onClick={scrollToTop}
+          aria-label="トップへ戻る"
+        >
+          <ArrowUp className="h-4 w-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="left">トップへ戻る</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -20,6 +20,7 @@ export function ScrollToTopButton() {
       }
     }
 
+    onScroll()
     window.addEventListener("scroll", onScroll, { passive: true })
     return () => window.removeEventListener("scroll", onScroll)
   }, [])
@@ -39,6 +40,7 @@ export function ScrollToTopButton() {
             visible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0"
           }`}
           onClick={scrollToTop}
+          tabIndex={visible ? 0 : -1}
           aria-label="トップへ戻る"
         >
           <ArrowUp className="h-4 w-4" />


### PR DESCRIPTION
# 概要

比較結果エリアが長い場合に、ワンクリックで画面トップに戻れるボタンを画面右下に設置する。

## 関連Issue

closes #29

## 変更内容

- `ScrollToTopButton` コンポーネントを新規作成
  - 300px 以上スクロールするとフェードインで表示
  - `prefers-reduced-motion` 対応（モーション軽減時は即座にスクロール）
  - ArrowUp アイコン + Tooltip（「トップへ戻る」）
- `page.tsx` にコンポーネントを配置

## 補足

- スクロールイベントは `passive: true` + ref による状態比較で不要な再レンダリングを抑制