### PR TITLE
fix: キーボードショートカット表示を OS に応じて切り替える

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import { ScrollToTopButton } from "@/components/ScrollToTopButton"
 import { useTextInput } from "@/hooks/useTextInput"
 import { useDiffCompare } from "@/hooks/useDiffCompare"
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts"
+import { useModKeyLabel } from "@/hooks/usePlatform"
 import type { WordMode, Theme, DiffDisplayMode, IgnoreOptions, ColorMode } from "@/lib/types"
 
 export default function Home() {
@@ -53,6 +54,8 @@ export default function Home() {
     lastComparedOptions,
     setLastComparedOptions,
   } = useDiffCompare(textA, textB, wordMode, ignoreOptions)
+
+  const modKey = useModKeyLabel()
 
   // Undo 用に現在の差分状態をキャプチャする
   const diffSnapshot = { result, resultVersion, lastComparedOptions }
@@ -151,7 +154,7 @@ export default function Home() {
             {optionsChanged && (
               <span className="text-xs text-muted-foreground animate-in fade-in duration-200">
                 <kbd className="mr-1 rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
-                  ⌘+Enter
+                  {modKey}+Enter
                 </kbd>
                 で再比較
               </span>

--- a/components/InputPanel.tsx
+++ b/components/InputPanel.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { ArrowLeftRight, Upload, X } from "lucide-react"
 import { MAX_TEXT_LENGTH } from "@/lib/constants"
+import { useModKeyLabel } from "@/hooks/usePlatform"
 
 /** 受け付けるファイル拡張子 */
 const ACCEPTED_EXTENSIONS = [".txt", ".md", ".csv", ".json", ".xml", ".html"]
@@ -69,6 +70,7 @@ export function InputPanel({
   const overLimitA = textA.length > MAX_TEXT_LENGTH
   const overLimitB = textB.length > MAX_TEXT_LENGTH
   const canCompare = textA.length > 0 && textB.length > 0 && !overLimitA && !overLimitB
+  const modKey = useModKeyLabel()
 
   const [dragOverA, setDragOverA] = useState(false)
   const [dragOverB, setDragOverB] = useState(false)
@@ -306,7 +308,7 @@ export function InputPanel({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <kbd className="font-mono text-[10px]">⌘+Enter</kbd>
+            <kbd className="font-mono text-[10px]">{modKey}+Enter</kbd>
           </TooltipContent>
         </Tooltip>
         <Tooltip>
@@ -321,7 +323,7 @@ export function InputPanel({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <kbd className="font-mono text-[10px]">⌘+Shift+X</kbd>
+            <kbd className="font-mono text-[10px]">{modKey}+Shift+X</kbd>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/hooks/usePlatform.ts
+++ b/hooks/usePlatform.ts
@@ -1,0 +1,32 @@
+/**
+ * 実行プラットフォームの判定フック。
+ * useSyncExternalStore で SSR / 初回ハイドレーションを false 固定にし、
+ * ハイドレーション完了後にクライアントの navigator.platform を反映する。
+ */
+
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+function subscribe(): () => void {
+  return () => {}
+}
+
+function getIsMacSnapshot(): boolean {
+  if (typeof navigator === "undefined") return false
+  return /Mac/i.test(navigator.platform)
+}
+
+function getIsMacServerSnapshot(): boolean {
+  return false
+}
+
+/** 実行環境が macOS かを返す。SSR & 初回レンダーでは false（Ctrl 表示）。 */
+export function useIsMac(): boolean {
+  return useSyncExternalStore(subscribe, getIsMacSnapshot, getIsMacServerSnapshot)
+}
+
+/** 修飾キーのラベル。macOS では "⌘"、それ以外では "Ctrl"。 */
+export function useModKeyLabel(): "⌘" | "Ctrl" {
+  return useIsMac() ? "⌘" : "Ctrl"
+}


### PR DESCRIPTION
# 概要

UI 上のショートカット表示 (`⌘+Enter` / `⌘+Shift+X`) がハードコードされており、
Windows/Linux ユーザーに誤った情報が表示されていた問題を修正。表示だけを
プラットフォームに追従させ、macOS では `⌘`、それ以外では `Ctrl` を表示する。

## 関連Issue

closes #36

## 変更内容

- `hooks/usePlatform.ts` を新規追加（`useIsMac` / `useModKeyLabel`）
  - `useSyncExternalStore` を使い、SSR / 初回ハイドレーションは `false`（Ctrl）固定、
    ハイドレーション完了後に `navigator.platform` を反映する SSR セーフ実装
- `app/page.tsx`: 再比較ヒントの `⌘+Enter` を `{modKey}+Enter` に差し替え
- `components/InputPanel.tsx`: 比較ボタン tooltip (`⌘+Enter`) とクリアボタン tooltip
  (`⌘+Shift+X`) を動的化

## 補足

- ショートカット実装 (`hooks/useKeyboardShortcuts.ts`) は既に `metaKey || ctrlKey`
  両対応のため変更不要。今回の修正は表示のみ。
- `navigator.userAgentData.platform` は Firefox/Safari で未対応のため、
  `navigator.platform` を `/Mac/i` で判定。
- SSR では常に `Ctrl` 表示、ハイドレーション後に macOS なら `⌘` に切り替わる。
  ツールチップは hover 時のみ表示されるため、初期レンダー時の瞬間的な差は実害なし。
- `npm run lint && npm run format:check` パス済み。