### PR TITLE
feat: オプション変更時に差分を自動で再比較する

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,6 @@ export default function Home() {
     setResultVersion,
     isComparing,
     handleCompare,
-    optionsChanged,
     lastComparedOptions,
     setLastComparedOptions,
   } = useDiffCompare(textA, textB, wordMode, ignoreOptions)
@@ -148,14 +147,6 @@ export default function Home() {
               onDisplayModeChange={setDisplayMode}
               onIgnoreOptionsChange={setIgnoreOptions}
             />
-            {optionsChanged && (
-              <span className="text-xs text-muted-foreground animate-in fade-in duration-200">
-                <kbd className="mr-1 rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
-                  ⌘+Enter
-                </kbd>
-                で再比較
-              </span>
-            )}
           </div>
 
           {result && (

--- a/hooks/useDiffCompare.ts
+++ b/hooks/useDiffCompare.ts
@@ -60,12 +60,18 @@ export function useDiffCompare(
     }, 0)
   }, [textA, textB, wordMode, ignoreOptions, canCompare])
 
-  // オプション変更後に再比較を促すためのフラグ
-  const optionsChanged =
-    result !== null &&
-    lastComparedOptions !== null &&
-    (lastComparedOptions.wordMode !== wordMode ||
-      lastComparedOptions.ignoreOptions.ignoreTrimWhitespace !== ignoreOptions.ignoreTrimWhitespace)
+  // オプション変更後、result が既にある場合のみデバウンス付きで自動再比較する
+  useEffect(() => {
+    if (!result || !lastComparedOptions) return
+    const changed =
+      lastComparedOptions.wordMode !== wordMode ||
+      lastComparedOptions.ignoreOptions.ignoreTrimWhitespace !== ignoreOptions.ignoreTrimWhitespace
+    if (!changed) return
+    const debounceTimer = setTimeout(() => {
+      handleCompare()
+    }, 250)
+    return () => clearTimeout(debounceTimer)
+  }, [wordMode, ignoreOptions, result, lastComparedOptions, handleCompare])
 
   return {
     result,
@@ -75,7 +81,6 @@ export function useDiffCompare(
     isComparing,
     canCompare,
     handleCompare,
-    optionsChanged,
     lastComparedOptions,
     setLastComparedOptions,
   }


### PR DESCRIPTION
# 概要

比較オプション（単語/文字モード・前後の空白を無視）の切り替え時に自動で差分を再比較するようにし、`⌘+Enter で再比較` のヒント UI を廃止した。切り替えが即反映されるため、ユーザーが手動で再実行する必要がなくなる。

## 関連Issue

closes #33

## 変更内容

- `useDiffCompare` に `wordMode` / `ignoreOptions` を監視する `useEffect` を追加し、`result` が存在する場合のみ 250ms デバウンスで `handleCompare` を自動実行
- 手動再比較用の `⌘+Enter で再比較` ヒント UI と `optionsChanged` フラグを削除
- `useDiffCompare` の戻り値から未使用となった `optionsChanged` を整理

## 補足

- `⌘+Enter` での手動再比較ショートカット自体は残存（`useKeyboardShortcuts`）
- 250ms のデバウンスはオプション連打時の無駄な計算を抑える目的。必要に応じて調整可能
- `npm run lint` / `npm run format:check` / `npm test`（既存 50 件）すべてパス