### PR TITLE
release: v1.6.0

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import { ScrollToTopButton } from "@/components/ScrollToTopButton"
 import { useTextInput } from "@/hooks/useTextInput"
 import { useDiffCompare } from "@/hooks/useDiffCompare"
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts"
+import { useModKeyLabel } from "@/hooks/usePlatform"
 import type { WordMode, Theme, DiffDisplayMode, IgnoreOptions, ColorMode } from "@/lib/types"
 
 export default function Home() {
@@ -53,6 +54,8 @@ export default function Home() {
     lastComparedOptions,
     setLastComparedOptions,
   } = useDiffCompare(textA, textB, wordMode, ignoreOptions)
+
+  const modKey = useModKeyLabel()
 
   // Undo 用に現在の差分状態をキャプチャする
   const diffSnapshot = { result, resultVersion, lastComparedOptions }
@@ -151,7 +154,7 @@ export default function Home() {
             {optionsChanged && (
               <span className="text-xs text-muted-foreground animate-in fade-in duration-200">
                 <kbd className="mr-1 rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
-                  ⌘+Enter
+                  {modKey}+Enter
                 </kbd>
                 で再比較
               </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,6 @@ import { ScrollToTopButton } from "@/components/ScrollToTopButton"
 import { useTextInput } from "@/hooks/useTextInput"
 import { useDiffCompare } from "@/hooks/useDiffCompare"
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts"
-import { useModKeyLabel } from "@/hooks/usePlatform"
 import type { WordMode, Theme, DiffDisplayMode, IgnoreOptions, ColorMode } from "@/lib/types"
 
 export default function Home() {
@@ -50,12 +49,9 @@ export default function Home() {
     setResultVersion,
     isComparing,
     handleCompare,
-    optionsChanged,
     lastComparedOptions,
     setLastComparedOptions,
   } = useDiffCompare(textA, textB, wordMode, ignoreOptions)
-
-  const modKey = useModKeyLabel()
 
   // Undo 用に現在の差分状態をキャプチャする
   const diffSnapshot = { result, resultVersion, lastComparedOptions }
@@ -151,14 +147,6 @@ export default function Home() {
               onDisplayModeChange={setDisplayMode}
               onIgnoreOptionsChange={setIgnoreOptions}
             />
-            {optionsChanged && (
-              <span className="text-xs text-muted-foreground animate-in fade-in duration-200">
-                <kbd className="mr-1 rounded border bg-muted px-1 py-0.5 font-mono text-[10px]">
-                  {modKey}+Enter
-                </kbd>
-                で再比較
-              </span>
-            )}
           </div>
 
           {result && (

--- a/components/InputPanel.tsx
+++ b/components/InputPanel.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { ArrowLeftRight, Upload, X } from "lucide-react"
 import { MAX_TEXT_LENGTH } from "@/lib/constants"
+import { useModKeyLabel } from "@/hooks/usePlatform"
 
 /** 受け付けるファイル拡張子 */
 const ACCEPTED_EXTENSIONS = [".txt", ".md", ".csv", ".json", ".xml", ".html"]
@@ -69,6 +70,7 @@ export function InputPanel({
   const overLimitA = textA.length > MAX_TEXT_LENGTH
   const overLimitB = textB.length > MAX_TEXT_LENGTH
   const canCompare = textA.length > 0 && textB.length > 0 && !overLimitA && !overLimitB
+  const modKey = useModKeyLabel()
 
   const [dragOverA, setDragOverA] = useState(false)
   const [dragOverB, setDragOverB] = useState(false)
@@ -306,7 +308,7 @@ export function InputPanel({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <kbd className="font-mono text-[10px]">⌘+Enter</kbd>
+            <kbd className="font-mono text-[10px]">{modKey}+Enter</kbd>
           </TooltipContent>
         </Tooltip>
         <Tooltip>
@@ -321,7 +323,7 @@ export function InputPanel({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            <kbd className="font-mono text-[10px]">⌘+Shift+X</kbd>
+            <kbd className="font-mono text-[10px]">{modKey}+Shift+X</kbd>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/hooks/useDiffCompare.ts
+++ b/hooks/useDiffCompare.ts
@@ -13,7 +13,7 @@ import type { WordMode, IgnoreOptions, DiffResult } from "@/lib/types"
 
 /**
  * テキスト差分比較の状態と実行ロジックを提供する。
- * @returns result / isComparing / optionsChanged など比較関連の状態一式
+ * @returns result / isComparing / lastComparedOptions など比較関連の状態一式
  */
 export function useDiffCompare(
   textA: string,
@@ -60,12 +60,18 @@ export function useDiffCompare(
     }, 0)
   }, [textA, textB, wordMode, ignoreOptions, canCompare])
 
-  // オプション変更後に再比較を促すためのフラグ
-  const optionsChanged =
-    result !== null &&
-    lastComparedOptions !== null &&
-    (lastComparedOptions.wordMode !== wordMode ||
-      lastComparedOptions.ignoreOptions.ignoreTrimWhitespace !== ignoreOptions.ignoreTrimWhitespace)
+  // オプション変更後、result が既にある場合のみデバウンス付きで自動再比較する
+  useEffect(() => {
+    if (!result || !lastComparedOptions) return
+    const changed =
+      lastComparedOptions.wordMode !== wordMode ||
+      lastComparedOptions.ignoreOptions.ignoreTrimWhitespace !== ignoreOptions.ignoreTrimWhitespace
+    if (!changed) return
+    const debounceTimer = setTimeout(() => {
+      handleCompare()
+    }, 250)
+    return () => clearTimeout(debounceTimer)
+  }, [wordMode, ignoreOptions, result, lastComparedOptions, handleCompare])
 
   return {
     result,
@@ -75,7 +81,6 @@ export function useDiffCompare(
     isComparing,
     canCompare,
     handleCompare,
-    optionsChanged,
     lastComparedOptions,
     setLastComparedOptions,
   }

--- a/hooks/usePlatform.ts
+++ b/hooks/usePlatform.ts
@@ -1,0 +1,32 @@
+/**
+ * 実行プラットフォームの判定フック。
+ * useSyncExternalStore で SSR / 初回ハイドレーションを false 固定にし、
+ * ハイドレーション完了後にクライアントの navigator.platform を反映する。
+ */
+
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+function subscribe(): () => void {
+  return () => {}
+}
+
+function getIsMacSnapshot(): boolean {
+  if (typeof navigator === "undefined") return false
+  return /Mac/i.test(navigator.platform)
+}
+
+function getIsMacServerSnapshot(): boolean {
+  return false
+}
+
+/** 実行環境が macOS かを返す。SSR & 初回レンダーでは false（Ctrl 表示）。 */
+export function useIsMac(): boolean {
+  return useSyncExternalStore(subscribe, getIsMacSnapshot, getIsMacServerSnapshot)
+}
+
+/** 修飾キーのラベル。macOS では "⌘"、それ以外では "Ctrl"。 */
+export function useModKeyLabel(): "⌘" | "Ctrl" {
+  return useIsMac() ? "⌘" : "Ctrl"
+}


### PR DESCRIPTION
# リリース概要

比較オプション変更時の自動再比較、OS に応じたショートカット表示切替、トップへ戻るボタンやクリアショートカットなどの UX 改善、および空白ハイライト・CI ワークフローのバグ修正を含むリリース。

## 含まれる変更

- feat: オプション変更時に差分を自動で再比較する (#43)
- fix: キーボードショートカット表示を OS に応じて切り替える (#42)
- feat: トップへ戻るボタンを画面右下に設置 (#31)
- feat: クリアボタンにキーボードショートカット (Cmd/Ctrl+Shift+X) を追加 (#30)
- fix: ignoreTrimWhitespace が内容差分のある行の空白ハイライトを抑制しない問題を修正 (#26)
- fix: クリアショートカットのキー判定と戻るボタンのアクセシビリティを改善
- fix: auto-release-tag のシェルインジェクション対策
- fix: タグ存在判定を固定文字列マッチに変更
- fix: auto-release-tag の if 条件修正とタグ作成の冪等化

## 関連Issue

closes #33, closes #36, closes #29, closes #28, closes #25

## 補足

なし