### PR TITLE
feat: ErrorBoundary に開発時スタックトレース表示と再編集導線を追加

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -14,35 +14,56 @@ interface Props {
 
 interface State {
   hasError: boolean
+  error: Error | null
+  errorInfo: ErrorInfo | null
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { hasError: false, error: null, errorInfo: null }
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true }
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    this.setState({ errorInfo: info })
     console.error("[ErrorBoundary]", error, info.componentStack)
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null })
   }
 
   render() {
     if (this.state.hasError) {
+      const isDev = process.env.NODE_ENV === "development"
       return (
-        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-6 text-center">
-          <p className="text-sm font-medium text-destructive">表示中にエラーが発生しました</p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="mt-3"
-            onClick={() => this.setState({ hasError: false })}
-          >
-            再試行
-          </Button>
+        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-6">
+          <p className="text-center text-sm font-medium text-destructive">
+            表示中にエラーが発生しました
+          </p>
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            「再試行」を押すか、入力内容を見直してから再度比較してください。
+          </p>
+          <div className="mt-3 flex justify-center">
+            <Button variant="outline" size="sm" onClick={this.handleRetry}>
+              再試行
+            </Button>
+          </div>
+          {isDev && this.state.error && (
+            <details className="mt-4 text-xs">
+              <summary className="cursor-pointer text-muted-foreground">
+                エラー詳細（開発環境のみ）
+              </summary>
+              <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-muted-foreground">
+                {this.state.error.message}
+                {this.state.errorInfo?.componentStack ?? ""}
+              </pre>
+            </details>
+          )}
         </div>
       )
     }


### PR DESCRIPTION
# 概要

DiffViewer をラップする ErrorBoundary が、レンダーエラー時に最低限のメッセージと再試行ボタンしか提供しておらず、原因調査もユーザー回復もしづらかった。リカバリ導線とデバッグ情報を拡充する。

## 関連Issue

closes #41

## 変更内容

- `state` に `error` / `errorInfo` を保持
- `componentDidCatch` で `errorInfo` を state に反映（`console.error` への出力は維持）
- 再試行ボタンに加え、入力の見直し / 再比較を促す説明文を追加
- 開発環境（`process.env.NODE_ENV === "development"`）のみ `<details>` でエラーメッセージ + componentStack を表示

## 補足

- 本番ビルドではエラー詳細の `<details>` は描画されない
- 動作確認は dev サーバ上で DiffViewer に一時的に throw を仕込んで実施（throw は revert 済み）