### PR TITLE
release: v1.7.0

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import { DiffViewer } from "@/components/DiffViewer"
 import { StatsRow } from "@/components/StatsRow"
 import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { ScrollToTopButton } from "@/components/ScrollToTopButton"
+import { ResizableContainer } from "@/components/ResizableContainer"
 import { useTextInput } from "@/hooks/useTextInput"
 import { useDiffCompare } from "@/hooks/useDiffCompare"
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts"
@@ -103,7 +104,7 @@ export default function Home() {
 
   return (
     <div>
-      <div className="mx-auto max-w-6xl px-4 py-4 md:py-6">
+      <ResizableContainer>
         <header className="flex items-center justify-between mb-6">
           <div>
             <h1 className="text-xl font-bold tracking-tight">gosabun</h1>
@@ -159,7 +160,7 @@ export default function Home() {
             </ErrorBoundary>
           )}
         </div>
-      </div>
+      </ResizableContainer>
 
       <ScrollToTopButton />
     </div>

--- a/components/DiffViewer.tsx
+++ b/components/DiffViewer.tsx
@@ -6,7 +6,7 @@
 "use client"
 
 import { useState, useMemo, useCallback, useRef } from "react"
-import { ChevronUp, ChevronDown } from "lucide-react"
+import { ChevronUp, ChevronDown, CheckCircle2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import type { DiffResult, DiffRowModel, DiffDisplayMode } from "@/lib/types"
 import { DiffRow } from "./DiffRow"
@@ -94,8 +94,14 @@ export function DiffViewer({ result, displayMode }: DiffViewerProps) {
 
   if (changeIndices.length === 0) {
     return (
-      <div className="rounded-md border p-8 text-center text-sm text-muted-foreground">
-        差分はありません
+      <div
+        className="flex items-center justify-center gap-2 rounded-md border border-green-600/30 bg-green-600/5 p-4 text-center dark:border-green-400/30 dark:bg-green-400/5"
+        role="status"
+      >
+        <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" aria-hidden="true" />
+        <p className="text-sm font-medium text-green-700 dark:text-green-300">
+          完全に一致しています
+        </p>
       </div>
     )
   }

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -14,35 +14,56 @@ interface Props {
 
 interface State {
   hasError: boolean
+  error: Error | null
+  errorInfo: ErrorInfo | null
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
-    this.state = { hasError: false }
+    this.state = { hasError: false, error: null, errorInfo: null }
   }
 
-  static getDerivedStateFromError(): State {
-    return { hasError: true }
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    this.setState({ errorInfo: info })
     console.error("[ErrorBoundary]", error, info.componentStack)
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null })
   }
 
   render() {
     if (this.state.hasError) {
+      const isDev = process.env.NODE_ENV === "development"
       return (
-        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-6 text-center">
-          <p className="text-sm font-medium text-destructive">表示中にエラーが発生しました</p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="mt-3"
-            onClick={() => this.setState({ hasError: false })}
-          >
-            再試行
-          </Button>
+        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-6">
+          <p className="text-center text-sm font-medium text-destructive">
+            表示中にエラーが発生しました
+          </p>
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            「再試行」を押すか、入力内容を見直してから再度比較してください。
+          </p>
+          <div className="mt-3 flex justify-center">
+            <Button variant="outline" size="sm" onClick={this.handleRetry}>
+              再試行
+            </Button>
+          </div>
+          {isDev && this.state.error && (
+            <details className="mt-4 text-xs">
+              <summary className="cursor-pointer text-muted-foreground">
+                エラー詳細（開発環境のみ）
+              </summary>
+              <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-all rounded bg-muted p-2 text-muted-foreground">
+                {this.state.error.message}
+                {this.state.errorInfo?.componentStack ?? ""}
+              </pre>
+            </details>
+          )}
         </div>
       )
     }

--- a/components/ResizableContainer.tsx
+++ b/components/ResizableContainer.tsx
@@ -1,0 +1,176 @@
+/**
+ * コンテナ幅を右端のハンドルでドラッグ可能にするラッパー。
+ * 下限は初期値（max-w-6xl = 1152px）、上限はビューポート幅に制限する。
+ * md 未満ではハンドル非表示・初期幅で固定する。
+ */
+
+"use client"
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react"
+import { GripVertical, Maximize2, Minimize2 } from "lucide-react"
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+const MIN_WIDTH_PX = 1152
+const VIEWPORT_PADDING_PX = 32
+const DESKTOP_MEDIA_QUERY = "(min-width: 768px)"
+
+function subscribeDesktopMq(callback: () => void) {
+  const mq = window.matchMedia(DESKTOP_MEDIA_QUERY)
+  mq.addEventListener("change", callback)
+  return () => mq.removeEventListener("change", callback)
+}
+
+function getDesktopMqSnapshot() {
+  return window.matchMedia(DESKTOP_MEDIA_QUERY).matches
+}
+
+function getDesktopMqServerSnapshot() {
+  return false
+}
+
+function subscribeViewportWidth(callback: () => void) {
+  window.addEventListener("resize", callback)
+  return () => window.removeEventListener("resize", callback)
+}
+
+function getViewportWidthSnapshot() {
+  return window.innerWidth
+}
+
+function getViewportWidthServerSnapshot() {
+  return 0
+}
+
+interface ResizableContainerProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function ResizableContainer({ children, className }: ResizableContainerProps) {
+  const isDesktop = useSyncExternalStore(
+    subscribeDesktopMq,
+    getDesktopMqSnapshot,
+    getDesktopMqServerSnapshot
+  )
+  const viewportWidth = useSyncExternalStore(
+    subscribeViewportWidth,
+    getViewportWidthSnapshot,
+    getViewportWidthServerSnapshot
+  )
+  const [width, setWidth] = useState<number | null>(null)
+  const draggingRef = useRef(false)
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(0)
+
+  const handlePointerMove = useCallback((e: PointerEvent) => {
+    if (!draggingRef.current) return
+    // コンテナは中央寄せのため、右端を dx 動かすと左端も同じだけ動く → 幅は 2 * dx 増える
+    const next = startWidthRef.current + (e.clientX - startXRef.current) * 2
+    const max = Math.max(MIN_WIDTH_PX, window.innerWidth - VIEWPORT_PADDING_PX)
+    setWidth(Math.min(Math.max(next, MIN_WIDTH_PX), max))
+  }, [])
+
+  const stopDragging = useCallback(() => {
+    if (!draggingRef.current) return
+    draggingRef.current = false
+    document.body.style.userSelect = ""
+    document.body.style.cursor = ""
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", stopDragging)
+    window.addEventListener("pointercancel", stopDragging)
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove)
+      window.removeEventListener("pointerup", stopDragging)
+      window.removeEventListener("pointercancel", stopDragging)
+      // ドラッグ中にアンマウントされた場合、body のインラインスタイルが残置されるのを防ぐ
+      stopDragging()
+    }
+  }, [handlePointerMove, stopDragging])
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDesktop) return
+      e.preventDefault()
+      draggingRef.current = true
+      startXRef.current = e.clientX
+      startWidthRef.current = width ?? MIN_WIDTH_PX
+      document.body.style.userSelect = "none"
+      document.body.style.cursor = "col-resize"
+    },
+    [isDesktop, width]
+  )
+
+  const isExpanded = width !== null && width > MIN_WIDTH_PX
+
+  const toggleExpanded = useCallback(() => {
+    if (isExpanded) {
+      setWidth(null)
+      return
+    }
+    const max = Math.max(MIN_WIDTH_PX, window.innerWidth - VIEWPORT_PADDING_PX)
+    setWidth(max)
+  }, [isExpanded])
+
+  const style = isDesktop && width !== null ? { maxWidth: `${width}px` } : undefined
+
+  // ハンドルはコンテナ右端（中央寄せ）に位置するよう、ビューポート右端からのオフセットを算出する
+  const containerWidth = Math.min(viewportWidth, width ?? MIN_WIDTH_PX)
+  const rightOffset = Math.max(0, (viewportWidth - containerWidth) / 2)
+  const showHandle = isDesktop && viewportWidth > 0
+
+  return (
+    <>
+      <div className={cn("relative mx-auto max-w-6xl px-4 py-4 md:py-6", className)} style={style}>
+        {children}
+      </div>
+      {showHandle && (
+        <div
+          className="pointer-events-none fixed inset-y-0 z-10"
+          style={{ right: `${rightOffset}px` }}
+        >
+          {/* 右端の常時可視な縦線 */}
+          <div aria-hidden className="absolute inset-y-0 right-0 w-px bg-border" />
+          {/* トグル + グリップ（縦中央に固定表示） */}
+          <div className="absolute right-0 top-1/2 flex -translate-y-1/2 translate-x-1/2 flex-col items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={toggleExpanded}
+                  aria-label={isExpanded ? "コンテナ幅を初期値に戻す" : "コンテナ幅を最大化"}
+                  aria-pressed={isExpanded}
+                  className="pointer-events-auto flex h-7 w-5 items-center justify-center rounded-full border bg-background shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  {isExpanded ? (
+                    <Minimize2 className="h-3 w-3 text-muted-foreground" />
+                  ) : (
+                    <Maximize2 className="h-3 w-3 text-muted-foreground" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="left">{isExpanded ? "最小化" : "最大化"}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label="コンテナ幅を変更"
+                  onPointerDown={handlePointerDown}
+                  className="pointer-events-auto flex h-12 w-5 cursor-col-resize touch-none items-center justify-center rounded-full border bg-background shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="left">ドラッグして幅を変更</TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/components/ResizableContainer.tsx
+++ b/components/ResizableContainer.tsx
@@ -120,7 +120,9 @@ export function ResizableContainer({ children, className }: ResizableContainerPr
   // ハンドルはコンテナ右端（中央寄せ）に位置するよう、ビューポート右端からのオフセットを算出する
   const containerWidth = Math.min(viewportWidth, width ?? MIN_WIDTH_PX)
   const rightOffset = Math.max(0, (viewportWidth - containerWidth) / 2)
-  const showHandle = isDesktop && viewportWidth > 0
+  // 可変余地（最低でも 1px 拡張できる幅）がない場合はハンドル・トグルを表示しない。
+  // 表示しても max が MIN_WIDTH_PX に張り付き、操作しても幅が変わらず壊れて見えるため。
+  const showHandle = isDesktop && viewportWidth > MIN_WIDTH_PX + VIEWPORT_PADDING_PX
 
   return (
     <>


### PR DESCRIPTION
# リリース概要

差分結果ビューの操作性とフィードバックを強化するリリース。コンテナ幅のリサイズ／最大化、ErrorBoundary のデバッグ情報拡充、差分なし時の成功 UI 化を含む。

## 含まれる変更

- feat: 結果コンテナ幅をリサイズ＆最大化トグルできるようにする (#46)
- feat: ErrorBoundary に開発時スタックトレース表示と再編集導線を追加 (#47)
- change: 差分なし時の表示をポジティブな成功 UI に変更 (#48)
- fix: 可変余地がないビューポート幅ではリサイズ UI を非表示にする

## 関連Issue

closes #45 , closes #41, closes #37

## 補足

なし