### PR TITLE
fix: 差分ナビ操作中もバー位置を sticky 固定に維持する (#51)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,6 +102,30 @@ export default function Home() {
     return () => observer.disconnect()
   }, [])
 
+  // 比較完了時、差分ナビゲーションバーが sticky 位置（OptionsBar 直下）に来るまで
+  // ページをスクロールし、初回クリックからバーの位置が変わらないようにする。
+  // Undo（resultVersion を過去値に戻す操作）では発火させない。
+  const diffViewerRef = useRef<HTMLDivElement>(null)
+  const prevResultVersionRef = useRef(resultVersion)
+  useEffect(() => {
+    const prev = prevResultVersionRef.current
+    prevResultVersionRef.current = resultVersion
+    if (resultVersion <= prev) return
+    if (!result) return
+    const el = diffViewerRef.current
+    if (!el) return
+
+    const stickyTopRaw = getComputedStyle(document.documentElement).getPropertyValue(
+      "--sticky-bar-height"
+    )
+    const stickyTop = parseFloat(stickyTopRaw) || 40
+    const targetY = el.getBoundingClientRect().top + window.scrollY - stickyTop
+    if (window.scrollY >= targetY) return
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    window.scrollTo({ top: targetY, behavior: prefersReducedMotion ? "auto" : "smooth" })
+  }, [resultVersion, result])
+
   return (
     <div>
       <ResizableContainer>
@@ -152,7 +176,9 @@ export default function Home() {
 
           {result && (
             <ErrorBoundary>
-              <DiffViewer key={resultVersion} result={result} displayMode={displayMode} />
+              <div ref={diffViewerRef}>
+                <DiffViewer key={resultVersion} result={result} displayMode={displayMode} />
+              </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <StatsRow label="テキスト A" stats={result.statsA} />
                 <StatsRow label="テキスト B" stats={result.statsB} />

--- a/components/DiffViewer.tsx
+++ b/components/DiffViewer.tsx
@@ -25,6 +25,7 @@ interface DiffViewerProps {
 }
 
 export function DiffViewer({ result, displayMode }: DiffViewerProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [currentChangeIdx, setCurrentChangeIdx] = useState(-1)
 
@@ -47,22 +48,41 @@ export function DiffViewer({ result, displayMode }: DiffViewerProps) {
     [displayRows]
   )
 
-  /** 指定した変更箇所インデックスの行までスクロールする */
+  /**
+   * 指定した変更箇所インデックスの行までスクロールする。
+   * 基本は対象行を viewport 中央に寄せるが、ナビゲーションバーが sticky 位置から
+   * 外れない最小 scrollY でクランプし、バーの画面位置が動かないようにする。
+   */
   const scrollToRow = useCallback(
     (changeIdx: number) => {
-      if (!containerRef.current || changeIdx < 0 || changeIdx >= changeIndices.length) return
+      if (!containerRef.current || !wrapperRef.current) return
+      if (changeIdx < 0 || changeIdx >= changeIndices.length) return
       const displayIdx = changeIndices[changeIdx]
       const target = containerRef.current.querySelector<HTMLElement>(
         `[data-diff-changed="${displayRows[displayIdx].originalIndex}"]`
       )
-      if (target) {
-        const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
-        target.scrollIntoView({
-          behavior: prefersReducedMotion ? "auto" : "smooth",
-          block: "center",
-        })
-        setCurrentChangeIdx(changeIdx)
-      }
+      if (!target) return
+
+      const stickyTopRaw = getComputedStyle(document.documentElement).getPropertyValue(
+        "--sticky-bar-height"
+      )
+      const stickyTop = parseFloat(stickyTopRaw) || 40
+
+      const targetRect = target.getBoundingClientRect()
+      const wrapperRect = wrapperRef.current.getBoundingClientRect()
+      // 中央寄せの理想 scrollY
+      const idealScrollY =
+        targetRect.top + window.scrollY - (window.innerHeight - targetRect.height) / 2
+      // バー（= wrapper の先頭）が sticky 位置に貼り付く最小 scrollY
+      const minScrollY = wrapperRect.top + window.scrollY - stickyTop
+      const finalScrollY = Math.max(idealScrollY, minScrollY)
+
+      const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      window.scrollTo({
+        top: finalScrollY,
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+      })
+      setCurrentChangeIdx(changeIdx)
     },
     [changeIndices, displayRows]
   )
@@ -107,7 +127,7 @@ export function DiffViewer({ result, displayMode }: DiffViewerProps) {
   }
 
   return (
-    <div className="space-y-2">
+    <div ref={wrapperRef} className="space-y-2">
       <div
         className="sticky z-5 flex items-center gap-1.5 bg-background py-1 text-xs text-muted-foreground"
         style={{ top: "var(--sticky-bar-height, 2.5rem)" }}


### PR DESCRIPTION
# 概要

差分ナビゲーションバーが sticky 位置に貼り付くまでスクロールに追従して動き、初回クリック後に
バーがカーソル下から外れて連続クリックできない問題（#51）を修正する。

## 関連Issue

closes #51

## 変更内容

- 比較完了時、DiffViewer の先頭が sticky 位置（OptionsBar 直下）に来るまでページを自動
  スクロールし、初回クリック時点でバーを sticky 状態にしておく（`app/page.tsx`）
  - `resultVersion` の単調増加で判定し、Undo（version 巻き戻し）では発火させない
  - 既にそれより下にスクロール済みなら何もしない
  - `prefers-reduced-motion` を尊重して `smooth` / `auto` を切替
- 「次へ／前へ」クリック時のスクロールを手動 `window.scrollTo` に変更し、「バーが sticky
  から外れない最小 scrollY」でクランプ（`components/DiffViewer.tsx`）
  - 末尾→先頭ループや「前へ」での上方向スクロールでもバーが sticky 解除されない
  - クランプが効いた場合、対象行は viewport 中央ではなくバー直下に表示される

## 補足

- 影響範囲は差分結果表示時のスクロール挙動のみ。
- 比較直後にページが自動スクロールするため、入力欄が画面外に押し出される（要件通り）。
- 「次へ」連打 / 末尾→先頭ループ / 「前へ」/ 手動上方スクロール後の各シナリオでバーが画面上の
  同じ位置に留まることをブラウザで動作確認してください。